### PR TITLE
Add UtilityType

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ that implements the same interface as the protocol and keeps track of interactio
 - [InitMacro](https://github.com/LeonardoCardoso/InitMacro): A Swift Macro implementation that generates initializers for classes and structs with support for default values, wildcards and access control.
 - [AssociatedObject](https://github.com/p-x9/AssociatedObject): A Swift Macro for adding stored properties in Extension to classes defined in external modules, etc.  
   (This is implemented by wrapping `objc_getAssociatedObject`/`objc_setAssociatedObject`.)
+- [UtilityType](https://github.com/bannzai/UtilityType): UtilityType is an innovative library designed to realize TypeScript's UtilityTypes in Swift. See more details: https://www.typescriptlang.org/docs/handbook/utility-types.html
+  - `@Partial`,`@Required`: Constructs a type with all properties set to optional(`@Partial`) or require(`@Required`). This utility will return a type that represents all subsets of a given type.
+  - `@Pick`,`@Omit`: Constructs a type by picking(`@Pick`) or removing(`@Omit`) the set of specific properties keys (only string literal) from attached Type.
+  - `@Exclude`,`@Extract`: Constructs a type by excluding(`@Exclude`) or extracting(`@Extract`) from enum all cases.
+  - `@Parameters`: Constructs a tuple type from the types used in the parameters of a function type.
+  - `@ReturnType`: Constructs a type consisting of the return type of function.
 ---
 
 _**Take part in this exciting evolution in Swift. Your contributions are most welcome!**_


### PR DESCRIPTION
Just found this repo and introduced and added a link swift macro about converting utility types like typescript I made. Thank you!

[UtilityType](https://github.com/bannzai/UtilityType): UtilityType is an innovative library designed to realize TypeScript's UtilityTypes in Swift. See more details: https://www.typescriptlang.org/docs/handbook/utility-types.html